### PR TITLE
Update 02.03

### DIFF
--- a/examples/controlled_temperature.cpp
+++ b/examples/controlled_temperature.cpp
@@ -36,20 +36,8 @@ const double stop = 10.0;
 const double step_size = 1E-4;
 const fmi2ValueReference vr = 46;
 
-int main() {
+void run(unique_ptr<fmi2CoSimulationSlave> &slave) {
 
-    const string fmu_path = "../resources/fmus/2.0/cs/20sim/4.6.4.8004/"
-                            "ControlledTemperature/ControlledTemperature.fmu";
-
-    auto fmu = fmi2Fmu(fmu_path).asCoSimulationFmu();
-
-    for (const auto &v : *fmu->getModelDescription()->modelVariables) {
-        if (v.causality == Causality::output) {
-            logger::info("Name={}, description={}", v.name, v.description);
-        }
-    }
-
-    auto slave = fmu->newInstance();
     slave->setupExperiment();
     slave->enterInitializationMode();
     slave->exitInitializationMode();
@@ -73,6 +61,15 @@ int main() {
     logger::info("Time elapsed={}s", elapsed);
 
     slave->terminate();
+}
+
+int main() {
+
+    const string fmu_path = "../resources/fmus/2.0/cs/20sim/4.6.4.8004/"
+                            "ControlledTemperature/ControlledTemperature.fmu";
+
+    auto fmu = fmi2Fmu(fmu_path).asCoSimulationFmu()->newInstance();
+    run(fmu);
     
     return 0;
 

--- a/include/fmi4cpp/common/driver/driver_options.hpp
+++ b/include/fmi4cpp/common/driver/driver_options.hpp
@@ -47,7 +47,7 @@ namespace fmi4cpp::driver {
 
         std::vector<fmi2::ScalarVariable> transformVariables(std::shared_ptr<const fmi2::ModelDescriptionBase> md) const {
             std::vector<fmi2::ScalarVariable> result;
-            std::transform(variables.begin(), variables.end(), result.begin(), [md](std::string name) -> fmi2::ScalarVariable {
+            std::transform(variables.begin(), variables.end(), std::back_inserter(result), [md](std::string name) -> fmi2::ScalarVariable {
                return md->getVariableByName(name);
             });
             return result;

--- a/include/fmi4cpp/common/driver/driver_options.hpp
+++ b/include/fmi4cpp/common/driver/driver_options.hpp
@@ -25,6 +25,7 @@
 #ifndef FMI4CPP_DRIVEROPTIONS_HPP
 #define FMI4CPP_DRIVEROPTIONS_HPP
 
+#include <algorithm>
 #include <experimental/filesystem>
 
 #include <fmi4cpp/fmi2/xml/ScalarVariable.hpp>
@@ -42,14 +43,16 @@ namespace fmi4cpp::driver {
         bool modelExchange = false;
         bool failOnLargeFileSize = false;
 
-        fs::path outputFolder = fs::current_path();
         std::vector<std::string> variables;
+        fs::path outputFolder = fs::current_path();
 
-        std::vector<fmi2::ScalarVariable> transformVariables(std::shared_ptr<const fmi2::ModelDescriptionBase> md) const {
+        std::vector<fmi2::ScalarVariable>
+        transformVariables(std::shared_ptr<const fmi2::ModelDescriptionBase> md) const {
             std::vector<fmi2::ScalarVariable> result;
-            std::transform(variables.begin(), variables.end(), std::back_inserter(result), [md](std::string name) -> fmi2::ScalarVariable {
-               return md->getVariableByName(name);
-            });
+            std::transform(variables.begin(), variables.end(), std::back_inserter(result),
+                           [md](std::string name) -> fmi2::ScalarVariable {
+                               return md->getVariableByName(name);
+                           });
             return result;
         }
 

--- a/include/fmi4cpp/common/driver/driver_options.hpp
+++ b/include/fmi4cpp/common/driver/driver_options.hpp
@@ -43,7 +43,15 @@ namespace fmi4cpp::driver {
         bool failOnLargeFileSize = false;
 
         fs::path outputFolder = fs::current_path();
-        std::vector<fmi4cpp::fmi2::ScalarVariable> variables;
+        std::vector<std::string> variables;
+
+        std::vector<fmi2::ScalarVariable> transformVariables(std::shared_ptr<const fmi2::ModelDescriptionBase> md) const {
+            std::vector<fmi2::ScalarVariable> result;
+            std::transform(variables.begin(), variables.end(), result.begin(), [md](std::string name) -> fmi2::ScalarVariable {
+               return md->getVariableByName(name);
+            });
+            return result;
+        }
 
     };
 

--- a/include/fmi4cpp/common/driver/fmu_driver.hpp
+++ b/include/fmi4cpp/common/driver/fmu_driver.hpp
@@ -40,18 +40,18 @@ namespace fmi4cpp::driver {
 
     public:
 
-        explicit fmu_driver(std::shared_ptr<fmi2::fmi2Fmu> fmu);
+        fmu_driver(const std::string &fmuPath, const driver_options &options);
 
-        void run(driver_options options);
+        void run();
 
     private:
 
-        const std::shared_ptr<fmi2::fmi2Fmu> fmu_;
+        const std::string &fmuPath_;
+        const driver_options &options_;
 
         void dumpOutput(const std::string &data, const std::string &outputFolder);
 
-        void simulate(std::unique_ptr<FmuSlave<fmi2::CoSimulationModelDescription>> slave,
-                      driver_options &options);
+        void simulate(std::unique_ptr<FmuSlave<fmi2::CoSimulationModelDescription>> slave);
 
     };
 

--- a/include/fmi4cpp/common/import/AbstractFmuInstance.hpp
+++ b/include/fmi4cpp/common/import/AbstractFmuInstance.hpp
@@ -40,6 +40,7 @@ namespace fmi4cpp {
 
         bool terminated_ = false;
         bool instanceFreed_ = false;
+        std::shared_ptr<FmuResource> resource_;
 
     protected:
 
@@ -50,9 +51,10 @@ namespace fmi4cpp {
     public:
 
         AbstractFmuInstance(fmi4cppComponent c,
+                            const std::shared_ptr<FmuResource> &resource,
                             const std::shared_ptr<FmiLibrary> &library,
                             const std::shared_ptr<const ModelDescription> &modelDescription)
-                : c_(c), library_(library), modelDescription_(modelDescription) {}
+                : c_(c), resource_(resource), library_(library), modelDescription_(modelDescription) {}
 
         std::shared_ptr<const ModelDescription> getModelDescription() const override {
             return modelDescription_;

--- a/include/fmi4cpp/common/import/AbstractFmuInstance.hpp
+++ b/include/fmi4cpp/common/import/AbstractFmuInstance.hpp
@@ -1,3 +1,5 @@
+#include <utility>
+
 /*
  * The MIT License
  *
@@ -51,10 +53,10 @@ namespace fmi4cpp {
     public:
 
         AbstractFmuInstance(fmi4cppComponent c,
-                            const std::shared_ptr<FmuResource> &resource,
+                            std::shared_ptr<FmuResource> resource,
                             const std::shared_ptr<FmiLibrary> &library,
                             const std::shared_ptr<const ModelDescription> &modelDescription)
-                : c_(c), resource_(resource), library_(library), modelDescription_(modelDescription) {}
+                : c_(c), resource_(std::move(resource)), library_(library), modelDescription_(modelDescription) {}
 
         std::shared_ptr<const ModelDescription> getModelDescription() const override {
             return modelDescription_;

--- a/include/fmi4cpp/fmi2/import/fmi2CoSimulationSlave.hpp
+++ b/include/fmi4cpp/fmi2/import/fmi2CoSimulationSlave.hpp
@@ -30,6 +30,7 @@
 #include "fmi2CoSimulationLibrary.hpp"
 
 #include "fmi4cpp/common/import/FmuSlave.hpp"
+#include "fmi4cpp/common/import/FmuResource.hpp"
 #include "fmi4cpp/common/import/AbstractFmuInstance.hpp"
 
 #include "fmi4cpp/fmi2/xml/ModelDescription.hpp"

--- a/include/fmi4cpp/fmi2/import/fmi2CoSimulationSlave.hpp
+++ b/include/fmi4cpp/fmi2/import/fmi2CoSimulationSlave.hpp
@@ -39,13 +39,14 @@
 namespace fmi4cpp::fmi2 {
 
     class fmi2CoSimulationSlave : public virtual FmuSlave<CoSimulationModelDescription>,
-                              public AbstractFmuInstance<fmi2CoSimulationLibrary, CoSimulationModelDescription> {
+                                  public AbstractFmuInstance<fmi2CoSimulationLibrary, CoSimulationModelDescription> {
 
     public:
 
         fmi2CoSimulationSlave(fmi2Component c,
-                          const std::shared_ptr<fmi2CoSimulationLibrary> &library,
-                          const std::shared_ptr<const CoSimulationModelDescription> &modelDescription);
+                              const std::shared_ptr<FmuResource> &resource,
+                              const std::shared_ptr<fmi2CoSimulationLibrary> &library,
+                              const std::shared_ptr<const CoSimulationModelDescription> &modelDescription);
 
         bool doStep(double stepSize) override;
 
@@ -82,15 +83,15 @@ namespace fmi4cpp::fmi2 {
 
         virtual bool readBoolean(fmi2ValueReference vr, fmi2Boolean &ref);
 
-        virtual bool readBoolean(const std::vector<fmi2ValueReference> &vr, std::vector<fmi2Boolean > &ref);
+        virtual bool readBoolean(const std::vector<fmi2ValueReference> &vr, std::vector<fmi2Boolean> &ref);
 
         virtual bool writeInteger(fmi2ValueReference vr, fmi2Integer value);
 
-        virtual bool writeInteger(const std::vector<fmi2ValueReference> &vr, const std::vector<fmi2Integer > &values);
+        virtual bool writeInteger(const std::vector<fmi2ValueReference> &vr, const std::vector<fmi2Integer> &values);
 
         virtual bool writeReal(fmi2ValueReference vr, fmi2Real value);
 
-        virtual bool writeReal(const std::vector<fmi2ValueReference> &vr, const std::vector<fmi2Real > &values);
+        virtual bool writeReal(const std::vector<fmi2ValueReference> &vr, const std::vector<fmi2Real> &values);
 
         virtual bool writeString(fmi2ValueReference vr, fmi2String value);
 
@@ -98,7 +99,7 @@ namespace fmi4cpp::fmi2 {
 
         virtual bool writeBoolean(fmi2ValueReference vr, fmi2Boolean value);
 
-        virtual bool writeBoolean(const std::vector<fmi2ValueReference> &vr, const std::vector<fmi2Boolean > &values);
+        virtual bool writeBoolean(const std::vector<fmi2ValueReference> &vr, const std::vector<fmi2Boolean> &values);
 
         virtual bool getFMUstate(fmi2FMUstate &state);
 
@@ -106,13 +107,14 @@ namespace fmi4cpp::fmi2 {
 
         virtual bool freeFMUstate(fmi2FMUstate &state);
 
-        virtual bool serializeFMUstate(const fmi2FMUstate &state, std::vector<fmi2Byte > &serializedState);
+        virtual bool serializeFMUstate(const fmi2FMUstate &state, std::vector<fmi2Byte> &serializedState);
 
-        virtual bool deSerializeFMUstate(fmi2FMUstate &state, const std::vector<fmi2Byte > &serializedState);
+        virtual bool deSerializeFMUstate(fmi2FMUstate &state, const std::vector<fmi2Byte> &serializedState);
 
         virtual bool getDirectionalDerivative(const std::vector<fmi2ValueReference> &vUnknownRef,
                                               const std::vector<fmi2ValueReference> &vKnownRef,
-                                              const std::vector<fmi2Real > &dvKnownRef, std::vector<fmi2Real> &dvUnknownRef);
+                                              const std::vector<fmi2Real> &dvKnownRef,
+                                              std::vector<fmi2Real> &dvUnknownRef);
 
     };
 

--- a/include/fmi4cpp/fmi2/import/fmi2Fmu.hpp
+++ b/include/fmi4cpp/fmi2/import/fmi2Fmu.hpp
@@ -45,14 +45,11 @@ class fmi2Fmu : public virtual FmuProvider<ModelDescription, fmi2CoSimulationFmu
 
     private:
 
-        const std::string fmuName_;
         std::shared_ptr<FmuResource> resource_;
         std::shared_ptr<const ModelDescription> modelDescription_;
 
     public:
         explicit fmi2Fmu(const std::string &fmuPath);
-
-        const std::string getFmuName() const;
 
         const std::string getModelDescriptionXml() const;
 

--- a/include/fmi4cpp/fmi2/import/fmi2ModelExchangeInstance.hpp
+++ b/include/fmi4cpp/fmi2/import/fmi2ModelExchangeInstance.hpp
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "fmi2ModelExchangeLibrary.hpp"
+#include "fmi4cpp/common/import/FmuResource.hpp"
 #include "fmi4cpp/common/import/AbstractFmuInstance.hpp"
 #include "fmi4cpp/fmi2/xml/ModelExchangeModelDescription.hpp"
 

--- a/include/fmi4cpp/fmi2/import/fmi2ModelExchangeInstance.hpp
+++ b/include/fmi4cpp/fmi2/import/fmi2ModelExchangeInstance.hpp
@@ -41,6 +41,7 @@ namespace fmi4cpp::fmi2 {
         fmi2EventInfo eventInfo_;
 
         fmi2ModelExchangeInstance(fmi2Component c,
+                              const std::shared_ptr<FmuResource> &resource,
                               const std::shared_ptr<fmi2ModelExchangeLibrary> &library,
                               const std::shared_ptr<const ModelExchangeModelDescription> &modelDescription);
 

--- a/include/fmi4cpp/fmi2/import/fmi2ModelExchangeSlave.hpp
+++ b/include/fmi4cpp/fmi2/import/fmi2ModelExchangeSlave.hpp
@@ -31,6 +31,7 @@
 #include "fmi2ModelExchangeInstance.hpp"
 
 #include "fmi4cpp/common/import/FmuSlave.hpp"
+#include "fmi4cpp/common/import/FmuResource.hpp"
 #include "fmi4cpp/common/solver/ModelExchangeSolver.hpp"
 
 #include "fmi4cpp/fmi2/xml/CoSimulationModelDescription.hpp"

--- a/include/fmi4cpp/fmi2/import/fmi2ModelExchangeSlave.hpp
+++ b/include/fmi4cpp/fmi2/import/fmi2ModelExchangeSlave.hpp
@@ -60,6 +60,7 @@ namespace fmi4cpp::fmi2 {
     private:
 
         solver::FmuWrapper sys_;
+        std::shared_ptr<FmuResource> resource_;
         std::shared_ptr<fmi2ModelExchangeInstance> instance_;
         std::unique_ptr<fmi4cpp::solver::ModelExchangeSolver> solver_;
         std::shared_ptr<const CoSimulationModelDescription> csModelDescription_;
@@ -72,7 +73,7 @@ namespace fmi4cpp::fmi2 {
 
     public:
 
-        fmi2ModelExchangeSlave(std::unique_ptr<fmi2ModelExchangeInstance> &instance,
+        fmi2ModelExchangeSlave(std::shared_ptr<FmuResource> &resource, std::unique_ptr<fmi2ModelExchangeInstance> &instance,
                            std::unique_ptr<fmi4cpp::solver::ModelExchangeSolver> &solver);
 
         const double getSimulationTime() const override;

--- a/src/fmi4cpp/common/driver/fmu_driver.cpp
+++ b/src/fmi4cpp/common/driver/fmu_driver.cpp
@@ -38,7 +38,7 @@ namespace {
 
     const char *CSV_SEPARATOR = ",";
 
-    void addHeader(vector<ScalarVariable> &variables, std::string &data) {
+    void addHeader(const vector<ScalarVariable> &variables, std::string &data) {
 
         data += "\"Time\", ";
 
@@ -51,7 +51,7 @@ namespace {
 
     }
 
-    void addRow(FmuSlave<CoSimulationModelDescription> &slave, vector<ScalarVariable> &variables, string &data) {
+    void addRow(FmuSlave<CoSimulationModelDescription> &slave, const vector<ScalarVariable> &variables, string &data) {
 
         data += "\n" + to_string(slave.getSimulationTime()) + CSV_SEPARATOR;
         for (unsigned int i = 0; i < variables.size(); i++) {

--- a/src/fmi4cpp/common/driver/fmu_driver.cpp
+++ b/src/fmi4cpp/common/driver/fmu_driver.cpp
@@ -131,9 +131,9 @@ void fmu_driver::simulate(std::unique_ptr<FmuSlave<CoSimulationModelDescription>
     slave->enterInitializationMode();
     slave->exitInitializationMode();
 
-
     string data;
     vector<ScalarVariable> variables = options_.transformVariables(slave->getModelDescription());
+
     addHeader(variables, data);
 
     addRow(*slave, variables, data);

--- a/src/fmi4cpp/common/driver/fmu_driver.cpp
+++ b/src/fmi4cpp/common/driver/fmu_driver.cpp
@@ -84,27 +84,33 @@ namespace {
 
 }
 
-fmu_driver::fmu_driver(const std::shared_ptr<fmi2Fmu> fmu) : fmu_(fmu){}
+fmu_driver::fmu_driver(const std::string &fmuPath, const driver_options &options) : fmuPath_(fmuPath), options_(options){}
 
-void fmu_driver::run(driver_options options) {
+void fmu_driver::run() {
 
-    if (options.modelExchange) {
+    fmi2::fmi2Fmu fmu(fmuPath_);
+
+    if (fmu.getModelDescription()->asCoSimulationModelDescription()->needsExecutionTool) {
+        throw Rejection("FMU requires execution tool.");
+    }
+
+    if (options_.modelExchange) {
 #ifdef FMI4CPP_WITH_ODEINT
         auto solver = solver::make_solver<solver::EulerSolver>(1E-3);
-        simulate(fmu_->asModelExchangeFmu()->newInstance(solver), options);
+        simulate(fmu.asModelExchangeFmu()->newInstance(solver));
 #else
         const char *msg = "Model Exchange mode selected, but driver has been built without odeint support!";
         throw Failure(msg);
 #endif
     } else {
-        simulate(fmu_->asCoSimulationFmu()->newInstance(), options);
+        simulate(fmu.asCoSimulationFmu()->newInstance());
     }
 
 }
 
 void fmu_driver::dumpOutput(const string &data, const string &outputFolder) {
 
-    const auto fmuName = fs::path(fmu_->getFmuName()).stem().string();
+    const auto fmuName = fs::path(fmuPath_).stem().string();
     const auto outputFile = fs::path(outputFolder + "/" + fmuName + "_out.csv");
     fs::create_directories(outputFile.parent_path());
 
@@ -115,20 +121,22 @@ void fmu_driver::dumpOutput(const string &data, const string &outputFolder) {
 
 }
 
-void fmu_driver::simulate(std::unique_ptr<FmuSlave<CoSimulationModelDescription>> slave, driver_options &options) {
+void fmu_driver::simulate(std::unique_ptr<FmuSlave<CoSimulationModelDescription>> slave) {
 
-    auto startTime = options.startTime;
-    auto stopTime = options.stopTime;
-    auto stepSize = options.stepSize;
+    auto startTime = options_.startTime;
+    auto stopTime = options_.stopTime;
+    auto stepSize = options_.stepSize;
 
     slave->setupExperiment(startTime);
     slave->enterInitializationMode();
     slave->exitInitializationMode();
 
-    string data = "";
-    addHeader(options.variables, data);
 
-    addRow(*slave, options.variables, data);
+    string data;
+    vector<ScalarVariable> variables = options_.transformVariables(slave->getModelDescription());
+    addHeader(variables, data);
+
+    addRow(*slave, variables, data);
     while (slave->getSimulationTime() <= stopTime) {
 
         if (!slave->doStep(stepSize)) {
@@ -136,13 +144,13 @@ void fmu_driver::simulate(std::unique_ptr<FmuSlave<CoSimulationModelDescription>
             throw Failure("Simulation terminated prematurely.");
         }
 
-        addRow(*slave, options.variables, data);
+        addRow(*slave, variables, data);
 
     }
 
     slave->terminate();
 
-    if (options.failOnLargeFileSize) {
+    if (options_.failOnLargeFileSize) {
         const size_t size = data.size();
         if (size >= 1e6) {
             double mbSize = ((double) size) / 1e6;
@@ -150,6 +158,6 @@ void fmu_driver::simulate(std::unique_ptr<FmuSlave<CoSimulationModelDescription>
         }
     }
 
-    dumpOutput(data, options.outputFolder.string());
+    dumpOutput(data, options_.outputFolder.string());
 
 }

--- a/src/fmi4cpp/fmi2/import/fmi2CoSimulationFmu.cpp
+++ b/src/fmi4cpp/fmi2/import/fmi2CoSimulationFmu.cpp
@@ -50,6 +50,6 @@ unique_ptr<fmi2CoSimulationSlave> fmi2CoSimulationFmu::newInstance(const bool vi
     }
     auto c = lib->instantiate(modelIdentifier, fmi2CoSimulation, guid(),
                                        resource_->getResourcePath(), visible, loggingOn);
-    return make_unique<fmi2CoSimulationSlave>(c, lib, modelDescription_);
+    return make_unique<fmi2CoSimulationSlave>(c, resource_, lib, modelDescription_);
 }
 

--- a/src/fmi4cpp/fmi2/import/fmi2CoSimulationSlave.cpp
+++ b/src/fmi4cpp/fmi2/import/fmi2CoSimulationSlave.cpp
@@ -28,9 +28,10 @@
 using namespace fmi4cpp::fmi2;
 
 fmi2CoSimulationSlave::fmi2CoSimulationSlave(const fmi2Component c,
+                                     const std::shared_ptr<FmuResource> &resource,
                                      const std::shared_ptr<fmi2CoSimulationLibrary> &library,
                                      const std::shared_ptr<const CoSimulationModelDescription> &modelDescription)
-        : AbstractFmuInstance<fmi2CoSimulationLibrary, CoSimulationModelDescription>(c, library, modelDescription) {}
+        : AbstractFmuInstance<fmi2CoSimulationLibrary, CoSimulationModelDescription>(c, resource, library, modelDescription) {}
 
 fmi4cpp::Status fmi2CoSimulationSlave::getLastStatus() const {
     return convert(library_->getLastStatus());

--- a/src/fmi4cpp/fmi2/import/fmi2CoSimulationSlave.cpp
+++ b/src/fmi4cpp/fmi2/import/fmi2CoSimulationSlave.cpp
@@ -28,7 +28,7 @@
 using namespace fmi4cpp::fmi2;
 
 fmi2CoSimulationSlave::fmi2CoSimulationSlave(const fmi2Component c,
-                                     const std::shared_ptr<FmuResource> &resource,
+                                     const std::shared_ptr<fmi4cpp::FmuResource> &resource,
                                      const std::shared_ptr<fmi2CoSimulationLibrary> &library,
                                      const std::shared_ptr<const CoSimulationModelDescription> &modelDescription)
         : AbstractFmuInstance<fmi2CoSimulationLibrary, CoSimulationModelDescription>(c, resource, library, modelDescription) {}

--- a/src/fmi4cpp/fmi2/import/fmi2Fmu.cpp
+++ b/src/fmi4cpp/fmi2/import/fmi2Fmu.cpp
@@ -42,11 +42,12 @@ using namespace fmi4cpp::fmi2;
 
 namespace fs = std::experimental::filesystem;
 
-fmi2Fmu::fmi2Fmu(const string &fmuPath): fmuName_(fs::path(fmuPath).stem().string()) {
+fmi2Fmu::fmi2Fmu(const string &fmuPath) {
 
     fmi4cpp::logger::debug("Loading FMU '{}'", fmuPath);
 
-    fs::path tmpPath(fs::temp_directory_path() /= fs::path("fmi4cpp_" + fmuName_ + "_" + generate_simple_id(8)));
+    const std::string fmuName = fs::path(fmuPath).stem().string();
+    fs::path tmpPath(fs::temp_directory_path() /= fs::path("fmi4cpp_" + fmuName + "_" + generate_simple_id(8)));
 
     if (!create_directories(tmpPath)) {
         auto err = "Failed to create temporary directory '" + tmpPath.string() + "' !";
@@ -65,9 +66,6 @@ fmi2Fmu::fmi2Fmu(const string &fmuPath): fmuName_(fs::path(fmuPath).stem().strin
     resource_ = make_shared<FmuResource>(tmpPath);
     modelDescription_ = std::move(parseModelDescription(resource_->getModelDescriptionPath()));
 
-}
- const std::string fmi2Fmu::getFmuName() const {
-    return fmuName_;
 }
 
 const std:: string fmi2Fmu::getModelDescriptionXml() const {

--- a/src/fmi4cpp/fmi2/import/fmi2ModelExchangeFmu.cpp
+++ b/src/fmi4cpp/fmi2/import/fmi2ModelExchangeFmu.cpp
@@ -53,11 +53,11 @@ std::unique_ptr<fmi2ModelExchangeInstance> fmi2ModelExchangeFmu::newInstance(boo
     }
     fmi2Component c = lib->instantiate(modelIdentifier, fmi2ModelExchange, guid(),
                                        resource_->getResourcePath(), visible, loggingOn);
-    return make_unique<fmi2ModelExchangeInstance>(c, lib, modelDescription_);
+    return make_unique<fmi2ModelExchangeInstance>(c, resource_, lib, modelDescription_);
 }
 
 std::unique_ptr<fmi2ModelExchangeSlave>
 fmi2ModelExchangeFmu::newInstance(std::unique_ptr<ModelExchangeSolver> &solver, bool visible, bool loggingOn) {
     unique_ptr<fmi2ModelExchangeInstance> instance = newInstance(visible, loggingOn);
-    return make_unique<fmi2ModelExchangeSlave>(instance, solver);
+    return make_unique<fmi2ModelExchangeSlave>(resource_, instance, solver);
 }

--- a/src/fmi4cpp/fmi2/import/fmi2ModelExchangeInstance.cpp
+++ b/src/fmi4cpp/fmi2/import/fmi2ModelExchangeInstance.cpp
@@ -28,9 +28,10 @@
 using namespace fmi4cpp::fmi2;
 
 fmi2ModelExchangeInstance::fmi2ModelExchangeInstance(const fmi2Component c,
+                                             const std::shared_ptr<FmuResource> &resource,
                                              const std::shared_ptr<fmi2ModelExchangeLibrary> &library,
                                              const std::shared_ptr<const ModelExchangeModelDescription> &modelDescription)
-        : AbstractFmuInstance<fmi2ModelExchangeLibrary, ModelExchangeModelDescription>(c, library, modelDescription) {}
+        : AbstractFmuInstance<fmi2ModelExchangeLibrary, ModelExchangeModelDescription>(c, resource, library, modelDescription) {}
 
 fmi4cpp::Status fmi2ModelExchangeInstance::getLastStatus() const {
     return convert(library_->getLastStatus());

--- a/src/fmi4cpp/fmi2/import/fmi2ModelExchangeInstance.cpp
+++ b/src/fmi4cpp/fmi2/import/fmi2ModelExchangeInstance.cpp
@@ -28,7 +28,7 @@
 using namespace fmi4cpp::fmi2;
 
 fmi2ModelExchangeInstance::fmi2ModelExchangeInstance(const fmi2Component c,
-                                             const std::shared_ptr<FmuResource> &resource,
+                                             const std::shared_ptr<fmi4cpp::FmuResource> &resource,
                                              const std::shared_ptr<fmi2ModelExchangeLibrary> &library,
                                              const std::shared_ptr<const ModelExchangeModelDescription> &modelDescription)
         : AbstractFmuInstance<fmi2ModelExchangeLibrary, ModelExchangeModelDescription>(c, resource, library, modelDescription) {}

--- a/src/fmi4cpp/fmi2/import/fmi2ModelExchangeSlave.cpp
+++ b/src/fmi4cpp/fmi2/import/fmi2ModelExchangeSlave.cpp
@@ -45,9 +45,10 @@ namespace {
 }
 
 fmi2ModelExchangeSlave::fmi2ModelExchangeSlave(
+        std::shared_ptr<FmuResource> &resource,
         std::unique_ptr<fmi2ModelExchangeInstance> &instance,
         std::unique_ptr<ModelExchangeSolver> &solver)
-        : instance_(std::move(instance)), solver_(std::move(solver)) {
+        : resource_(std::move(resource)), instance_(std::move(instance)), solver_(std::move(solver)) {
 
     sys_.instance_ = instance_;
     csModelDescription_ = wrap(*instance_->getModelDescription());

--- a/src/fmi4cpp/fmi2/import/fmi2ModelExchangeSlave.cpp
+++ b/src/fmi4cpp/fmi2/import/fmi2ModelExchangeSlave.cpp
@@ -39,13 +39,13 @@ namespace {
         CoSimulationAttributes attributes(me);
         attributes.canHandleVariableCommunicationStepSize = true;
         attributes.maxOutputDerivativeOrder = 0;
-        return std::make_unique<CoSimulationModelDescription>(CoSimulationModelDescription(me, attributes));
+        return std::make_shared<CoSimulationModelDescription>(CoSimulationModelDescription(me, attributes));
     }
 
 }
 
 fmi2ModelExchangeSlave::fmi2ModelExchangeSlave(
-        std::shared_ptr<FmuResource> &resource,
+        std::shared_ptr<fmi4cpp::FmuResource> &resource,
         std::unique_ptr<fmi2ModelExchangeInstance> &instance,
         std::unique_ptr<ModelExchangeSolver> &solver)
         : resource_(std::move(resource)), instance_(std::move(instance)), solver_(std::move(solver)) {

--- a/tool/fmu_driver.cpp
+++ b/tool/fmu_driver.cpp
@@ -98,7 +98,6 @@ int main(int argc, char** argv) {
     }
 
     const string fmuPath = vm["fmu"].as<string>();
-    auto fmu = make_shared<fmi2Fmu>(fmuPath);
 
     if (!vm.count("variables")) {
         cerr << "Missing variables to print.. Please try again." << endl;
@@ -107,10 +106,7 @@ int main(int argc, char** argv) {
 
     driver_options options;
 
-    auto variables = vm["variables"].as<vector<string>>();
-    for (const auto v : variables) {
-        options.variables.push_back(fmu->getModelDescription()->getVariableByName(v));
-    }
+    options.variables = vm["variables"].as<vector<string>>();
 
     if (vm.count(START)) {
         options.startTime = vm[START].as<double>();
@@ -130,8 +126,8 @@ int main(int argc, char** argv) {
         options.modelExchange = true;
     }
 
-    fmu_driver driver(fmu);
-    driver.run(options);
+    fmu_driver driver(fmuPath, options);
+    driver.run();
 
     return 0;
 


### PR DESCRIPTION
* Remove fmuName_ field from fmi2Fmu and corresponding getter
* Pass FmuResource to FMU instances, allowing them to outlive the scope of the FMUwho initialized them
* Refactor cross checker and fmu driver