### PR TITLE
Revert conan boost to boost/1.66.0@conan/stable

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-boost/1.69.0
+boost/1.66.0@conan/stable
 libzip/1.5.2@bincrafters/stable
 bzip2/1.0.8
 zlib/1.2.11


### PR DESCRIPTION
Reverts #88 

@gocarlos You made an issue erlier about updating the conan boost version. I seem to have the revert the change as it does not seem to behave the same way as the old version in regards to copying dlls. I did not catch this as my system probably loaded cached dlls when I ran tests locally. 