### PR TITLE
Adding functions to access dll handle of fmu instances

### DIFF
--- a/include/fmi4cpp/fmi2/cs_slave.hpp
+++ b/include/fmi4cpp/fmi2/cs_slave.hpp
@@ -53,6 +53,7 @@ public:
 
     [[nodiscard]] std::shared_ptr<const cs_model_description> get_model_description() const override;
 
+    [[nodiscard]] DLL_HANDLE handle() const override;
     [[nodiscard]] status last_status() const override;
 
     bool setup_experiment(double start = 0, double stop = 0, double tolerance = 0) override;

--- a/include/fmi4cpp/fmi2/fmi2_library.hpp
+++ b/include/fmi4cpp/fmi2/fmi2_library.hpp
@@ -86,6 +86,7 @@ protected:
 public:
     fmi2_library(const std::string& modelIdentifier, const std::shared_ptr<fmu_resource>& resource);
 
+    [[nodiscard]] DLL_HANDLE handle() const;
     [[nodiscard]] fmi2Status last_status() const;
     [[nodiscard]] fmi2String get_version() const;
     [[nodiscard]] fmi2String get_types_platform() const;

--- a/include/fmi4cpp/fmi2/me_instance.hpp
+++ b/include/fmi4cpp/fmi2/me_instance.hpp
@@ -69,6 +69,8 @@ public:
 
     bool new_discrete_states();
 
+    [[nodiscard]] DLL_HANDLE handle() const override;
+
     [[nodiscard]] fmi4cpp::status last_status() const override;
 };
 

--- a/include/fmi4cpp/fmu_instance.hpp
+++ b/include/fmi4cpp/fmu_instance.hpp
@@ -26,6 +26,7 @@
 #define FMI4CPP_FMUINSTANCE_HPP
 
 #include <fmi4cpp/fmu_variable_accessor.hpp>
+#include <fmi4cpp/dll_handle.hpp>
 #include <fmi4cpp/status.hpp>
 #include <fmi4cpp/types.hpp>
 
@@ -47,6 +48,8 @@ public:
     {
         return simulationTime_;
     }
+
+    [[nodiscard]] virtual DLL_HANDLE handle() const = 0;
 
     [[nodiscard]] virtual fmi4cpp::status last_status() const = 0;
 

--- a/src/fmi4cpp/fmi2/cs_slave.cpp
+++ b/src/fmi4cpp/fmi2/cs_slave.cpp
@@ -34,6 +34,11 @@ cs_slave::cs_slave(fmi2Component c,
     : fmu_instance_base<cs_library, cs_model_description>(c, resource, library, modelDescription)
 {}
 
+DLL_HANDLE cs_slave::handle() const
+{
+    return library_->handle();
+}
+
 fmi4cpp::status cs_slave::last_status() const
 {
     return convert(library_->last_status());

--- a/src/fmi4cpp/fmi2/fmi2_library.cpp
+++ b/src/fmi4cpp/fmi2/fmi2_library.cpp
@@ -135,6 +135,11 @@ bool fmi2_library::update_status_and_return_true_if_ok(fmi2Status status)
     return status == fmi2OK;
 }
 
+DLL_HANDLE fmi2_library::handle() const
+{
+    return handle_;
+}
+
 fmi2Status fmi2_library::last_status() const
 {
     return lastStatus_;

--- a/src/fmi4cpp/fmi2/me_instance.cpp
+++ b/src/fmi4cpp/fmi2/me_instance.cpp
@@ -34,6 +34,11 @@ me_instance::me_instance(fmi2Component c,
     : fmu_instance_base<me_library, me_model_description>(c, resource, library, modelDescription)
 {}
 
+DLL_HANDLE me_instance::handle() const
+{
+    return library_->handle();
+}
+
 fmi4cpp::status me_instance::last_status() const
 {
     return convert(library_->last_status());


### PR DESCRIPTION
I ran into a situation where I needed to call a function that was not implemented according to the FMI standard, but was in the same DLL (a callback, something the FMI 2.0 standard does not support). This requires "raw" access to the underlying DLL or SO. I understand that this bypasses the FMI standard, but that's exactly the point: in the end an FMU is just a DLL, and the DLL can be more than just an FMU :)