### PR TITLE
improve security by minimizing token permissions

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -2,10 +2,14 @@ name: FMI4cpp CI
 
 on: [ push, workflow_dispatch ]
 
+permissions:
+  contents: read
+
 jobs:
 
   cmake-on-linux:
-
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -31,7 +35,8 @@ jobs:
 
 
   vcpkg-on-linux:
-
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     env:
       CC: gcc-${{ matrix.compiler_version }}
@@ -65,7 +70,8 @@ jobs:
 
 
   vcpkg-on-windows:
-
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Hi, This follows [GitHub’s official best practices](https://docs.github.com/en/actions/reference/security/secure-use#use-secrets-for-sensitive-information) for workflows and helps improve security by minimizing token permissions.
